### PR TITLE
Removing Logi Capture from the equation

### DIFF
--- a/scripts/StartStream.ps1
+++ b/scripts/StartStream.ps1
@@ -19,11 +19,6 @@ Import-Module -Name $coreFunctionsModule -Force
 
 try {
     Open-Header
-
-    # Launch LogiCapture for the camera to be in the appropriate position
-    Write-Log "Launching LogiCapture software..."
-    Start-Process -WindowStyle Hidden -FilePath $webcamExecutablePath
-    Write-Log "Launched LogiCapture software."
     
     # Launch OBS to begin streaming.
     Write-Log "Launching OBS software..."


### PR DESCRIPTION
Simplifying the setup and improving by adding new scenes:

- After a good few hours troubleshooting, I've determined that my cameras will work when plugged into explicit USB controllers and when not initialized by Logi Capture (just using OBS natively). From a code perspective I'm simply removing the Logi Capture process start from the `StartStream.ps1` script
- Setup the scenes and now have a much better overall streaming experience, just in time for friends to come over this weekend!

Learned about OBS hotkeys and set the following up:
- `Ctrl + 1` to access the Player 1 solo scene
- `Ctrl + 2` to access the Player 2 solo scene
- `Ctrl + 3 ` to access the Two Player scene
- `Ctrl + 4` to access the 'Be Right Back' scene